### PR TITLE
Enabling driving channel for web socket connection with web-mobile driver app

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,7 @@
 // https://github.com/apneadiving/Google-Maps-for-Rails
 // require gmaps/google
 
-//      = require_tree ./channels
+//= require_tree ./channels
 
 //= require humane-rails
 //= require underscore

--- a/app/assets/javascripts/channels/driving.js
+++ b/app/assets/javascripts/channels/driving.js
@@ -1,0 +1,61 @@
+// app/assets/javascripts/channels/driving.js
+
+//= require cable
+//= require_self
+//= require_tree .
+
+// Call this from the driving page to set up the DrivingChannel to the server
+// Then use App.driving.XXX methods to communicate to the server
+function createDrivingChannel(connectedCallBack, disconnectedCallBack, receiveCallBack) {
+  "use strict";
+
+  App.driving = App.cable.subscriptions.create('DrivingChannel', {
+    // Built-in, called by framework whenever connection is established
+    connected: function (data) {
+      console.log('DriverChannel connection to server established'); // debugging
+      connectedCallBack();
+    },
+
+    // Built-in, called by framework whenever connection is broken
+    disconnected: function() {
+      console.log('DriverChannel connection to server disconnected'); // debugging
+      disconnectedCallBack();
+    },
+
+    // Built-in, called by framework whenever data arrives from server
+    received: function(data) {
+      console.log('DriverChannel got data ' + JSON.stringify(data)); // debugging
+      receiveCallBack(data);
+    },
+
+    // Outbound, send current location to server
+    send_location: function() {
+      if ("geolocation" in navigator) {
+        navigator.geolocation.getCurrentPosition(
+          function(position) {
+            var data = {'latitude': position.coords.latitude, 'longitude': position.coords.longitude};
+            this.perform('location_update', data);
+          },
+          function() {
+            console.log('unable to get current position')
+          }
+        )
+      }
+      else {
+        console.log('there is no geolocation available')
+      }
+    },
+
+    // Outbound, send available status to server
+    send_available: function() {
+      console.log('sending available')
+      this.perform('available');
+    },
+
+    // Outbound, send unavailable status to server
+    send_unavailable: function() {
+      console.log('sending unavailable')
+      this.perform('unavailable');
+    }
+  });
+}

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,5 +1,19 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+    def find_verified_user
+      if current_user = env['warden'].user # devise user
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/driving_channel.rb
+++ b/app/channels/driving_channel.rb
@@ -1,0 +1,36 @@
+class DrivingChannel < ApplicationCable::Channel
+  # called when a new driver connection is established
+  def subscribed
+    logger.debug "DrivingChannel connection from #{current_user.name}"
+    # Set up a stream specific to this driver
+    stream_from "driving_channel_#{current_user.id}"
+    # Set up a ridezone-specific stream, e.g. for stats about the ride zone (total # rides, active drivers, etc)
+    stream_from "ridezone_channel_#{current_user.ride_zone_id}"
+
+    # DEMO ONLY - just to show how we would broadcast "ride available" to the driver or other bits of info
+    Thread.new do
+      while true do
+        ActionCable.server.broadcast "driving_channel_#{current_user.id}", { type: 'ride_available', data: {time: Time.now.iso8601, latitude: 1, longitude: 2} }
+        sleep(5)
+        ActionCable.server.broadcast "ridezone_channel_#{current_user.ride_zone_id}", { type: 'stats', data: {time: Time.now.iso8601, drivers: 3} }
+        sleep(5)
+      end
+    end
+  end
+
+  # driver app is giving us new location
+  def location_update data
+    current_user.update_attributes({latitude: data['latitude'], longitude: data['longitude']})
+  end
+
+  # driver app telling us it is available
+  def available
+    current_user.update_attribute :available, true
+    # todo: this should trigger some task to find the driver a nearby rider
+  end
+
+  # driver app telling us it is available
+  def unavailable
+    current_user.update_attribute :available, false
+  end
+end

--- a/app/controllers/driving_controller.rb
+++ b/app/controllers/driving_controller.rb
@@ -1,0 +1,5 @@
+class DrivingController < ApplicationController
+  # GET /driving driving home page
+  def index
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
 
   after_create :add_rolify_role
   after_create :send_welcome_email
+  belongs_to :ride_zone
 
   # scope :admins, -> { where(user_type: :admin) }
   # scope :dispatchers, -> { where(user_type: :dispatcher) }

--- a/app/views/driving/index.html.haml
+++ b/app/views/driving/index.html.haml
@@ -1,0 +1,14 @@
+:javascript
+  function c() { document.getElementById('server-status').innerText = "Connected!"; }
+  function d() { document.getElementById('server-status').innerText = "Disconnected..."; }
+  function r(data) { document.getElementById('received-data').innerText = JSON.stringify(data); }
+  createDrivingChannel(c, d, r);
+
+Driving App
+
+<div id="server-status">Waiting for connection</div>
+<div id="received-data">No data</div>
+
+<input type=submit onclick="javascript: App.driving.send_available()" value="Available"/>
+<input type=submit onclick="javascript: App.driving.send_unavailable()" value="Unavailable"/>
+<input type=submit onclick="javascript: App.driving.send_location()" value="Send Location"/>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,11 +12,11 @@
 
 Rails.application.configure do
   Rails.env = 'development'
-  
+
   # Websocket for messages
-  # config.action_cable.url = "ws://local.drive.vote:3000/cable"
-  # config.action_cable.allowed_request_origins = ['http://local.drive.vote:3000']
-  
+  config.action_cable.url = "ws://local.drive.vote:3000/cable"
+  config.action_cable.allowed_request_origins = ['http://local.drive.vote:3000']
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -45,7 +45,7 @@ Rails.application.configure do
   end
 
   config.active_job.queue_adapter = :sidekiq
-  
+
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
@@ -57,7 +57,7 @@ Rails.application.configure do
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
-  
+
   # More info here:
   # http://weblog.rubyonrails.org/2015/1/16/This-week-in-Rails-tokens-migrations-method-source-and-more/
   config.active_record.time_zone_aware_types = [:datetime, :time]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,10 +22,11 @@ Rails.application.routes.draw do
   # and the meta tag in application.html.haml
   # and lined in development.rb and production.rb
   # Serve websocket cable requests in-process
-  # mount ActionCable.server => '/cable'
+  mount ActionCable.server => '/cable'
 
   resources :campaigns, only: [:index, :show]
   resources :elections, only: [:index, :show]
+  resources :driving, only: [:index]
 
   resources :users do #, only: [:show, :new, :create, :edit, :update]
     get :confirm, on: :member

--- a/db/migrate/20160805054956_add_available_to_users.rb
+++ b/db/migrate/20160805054956_add_available_to_users.rb
@@ -1,0 +1,6 @@
+class AddAvailableToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :available, :boolean, default: false
+    add_column :users, :ride_zone_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160804035225) do
+ActiveRecord::Schema.define(version: 20160805054956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,41 +106,43 @@ ActiveRecord::Schema.define(version: 20160804035225) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                                                             null: false
-    t.string   "email",                                               default: "", null: false
-    t.string   "encrypted_password",                                  default: "", null: false
+    t.string   "name",                                                                null: false
+    t.string   "email",                                               default: "",    null: false
+    t.string   "encrypted_password",                                  default: "",    null: false
     t.integer  "agree_to_background_check"
     t.integer  "accepted_tos"
     t.integer  "email_list"
     t.integer  "party_affiliation"
-    t.string   "phone_number",                                        default: "", null: false
+    t.string   "phone_number",                                        default: "",    null: false
     t.string   "phone_number_normalized"
-    t.string   "image_url",                                           default: "", null: false
-    t.string   "locale",                                              default: "", null: false
-    t.string   "languages",                                           default: "", null: false
+    t.string   "image_url",                                           default: "",    null: false
+    t.string   "locale",                                              default: "",    null: false
+    t.string   "languages",                                           default: "",    null: false
     t.integer  "max_passengers"
     t.time     "start_drive_time"
     t.time     "end_drive_time"
     t.text     "description"
-    t.string   "address1",                                            default: "", null: false
-    t.string   "address2",                                            default: "", null: false
-    t.string   "city",                                                default: "", null: false
-    t.string   "state",                                               default: "", null: false
-    t.string   "zip",                                                 default: "", null: false
-    t.string   "country",                                             default: "", null: false
+    t.string   "address1",                                            default: "",    null: false
+    t.string   "address2",                                            default: "",    null: false
+    t.string   "city",                                                default: "",    null: false
+    t.string   "state",                                               default: "",    null: false
+    t.string   "zip",                                                 default: "",    null: false
+    t.string   "country",                                             default: "",    null: false
     t.decimal  "latitude",                  precision: 15, scale: 10
     t.decimal  "longitude",                 precision: 15, scale: 10
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                                       default: 0,  null: false
+    t.integer  "sign_in_count",                                       default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",                                  default: "", null: false
-    t.string   "last_sign_in_ip",                                     default: "", null: false
-    t.datetime "created_at",                                                       null: false
-    t.datetime "updated_at",                                                       null: false
-    t.integer  "language",                                            default: 0,  null: false
+    t.string   "current_sign_in_ip",                                  default: "",    null: false
+    t.string   "last_sign_in_ip",                                     default: "",    null: false
+    t.datetime "created_at",                                                          null: false
+    t.datetime "updated_at",                                                          null: false
+    t.integer  "language",                                            default: 0,     null: false
+    t.boolean  "available",                                           default: false
+    t.integer  "ride_zone_id"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["phone_number_normalized"], name: "index_users_on_phone_number_normalized", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree


### PR DESCRIPTION
Some demo functionality at this point to demonstrate capabilities. Should run locally. You need to sign in first, then go to http://local.drive.vote/driving. Note that desktop chrome at least will not send location because server is not HTTPS.

This will probably not work at Heroku without further configuration (like config.action_cable.url and config.action_cable.allowed_request_origins)

Need to determine testing strategy too