### PR TITLE
Relax phone number only unique index 

### DIFF
--- a/app/controllers/admin/twilio_controller.rb
+++ b/app/controllers/admin/twilio_controller.rb
@@ -48,9 +48,9 @@ class Admin::TwilioController < Admin::AdminApplicationController
   def establish_user_conversation
     to_phone = PhonyRails.normalize_number(params['To'])
     from_phone = PhonyRails.normalize_number(params['From'])
-    pseudo_name = "#{from_phone} via sms"
+    sms_name = User.sms_name(from_phone)
     attrs = {
-        name: pseudo_name,
+        name: sms_name,
         user_type: 'voter',
         password: '12345678',
         phone_number: from_phone,
@@ -61,7 +61,7 @@ class Admin::TwilioController < Admin::AdminApplicationController
     @user = begin
       User.create!(attrs)
     rescue ActiveRecord::RecordNotUnique
-      User.where(phone_number_normalized: from_phone, name: pseudo_name).first
+      User.where(phone_number_normalized: from_phone, name: sms_name).first
     end
     @conversation = Conversation.where(user_id: @user.id).where.not(status: :closed).first
     @conversation ||= Conversation.create(user_id: @user.id, from_phone: from_phone, to_phone: to_phone, ride_zone: @ride_zone)

--- a/app/controllers/admin/twilio_controller.rb
+++ b/app/controllers/admin/twilio_controller.rb
@@ -48,10 +48,20 @@ class Admin::TwilioController < Admin::AdminApplicationController
   def establish_user_conversation
     to_phone = PhonyRails.normalize_number(params['To'])
     from_phone = PhonyRails.normalize_number(params['From'])
-    @user = User.find_by_phone_number_normalized(from_phone)
-    if @user.nil?
-      @user = User.create!(name: '', user_type: 'rider', password: '12345678', phone_number: from_phone, phone_number_normalized: from_phone, email: "#{from_phone}@sms.org")
-      # todo: user role as passenger?
+    pseudo_name = "#{from_phone} via sms"
+    attrs = {
+        name: pseudo_name,
+        user_type: 'voter',
+        password: '12345678',
+        phone_number: from_phone,
+        phone_number_normalized: from_phone,
+        email: "#{Time.now.to_f}@not.adomain"
+    }
+    # create the user and rescue duplicate record error to find existing one
+    @user = begin
+      User.create!(attrs)
+    rescue ActiveRecord::RecordNotUnique
+      User.where(phone_number_normalized: from_phone, name: pseudo_name).first
     end
     @conversation = Conversation.where(user_id: @user.id).where.not(status: :closed).first
     @conversation ||= Conversation.create(user_id: @user.id, from_phone: from_phone, to_phone: to_phone, ride_zone: @ride_zone)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -18,7 +18,7 @@ class Conversation < ApplicationRecord
   def calculated_lifecycle
     if user.unknown_language?
       lckey = :need_language
-    elsif user.name.blank?
+    elsif user.name.blank? || user.has_sms_name?
       lckey = :need_name
     elsif from_latitude.nil? || from_longitude.nil?
       lckey = :need_origin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,14 @@ class User < ApplicationRecord
     [self.address1, self.address2, self.city, self.state, self.zip, self.country].compact.join(', ')
   end
 
+  def self.sms_name(phone_number)
+    "#{phone_number} via sms"
+  end
+
+  def has_sms_name?
+    self.name == User.sms_name(self.phone_number)
+  end
+
   def has_required_fields?
     !!(self.email? && self.name? && self.phone_number? && self.city? && self.state? && self.zip)
   end

--- a/db/migrate/20160807114729_change_user_phone_index.rb
+++ b/db/migrate/20160807114729_change_user_phone_index.rb
@@ -1,0 +1,6 @@
+class ChangeUserPhoneIndex < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :users, :phone_number_normalized
+    add_index :users, [:phone_number_normalized, :name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160805212014) do
+ActiveRecord::Schema.define(version: 20160807114729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,7 +142,7 @@ ActiveRecord::Schema.define(version: 20160805212014) do
     t.integer  "language",                                            default: 0,     null: false
     t.boolean  "available",                                           default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["phone_number_normalized"], name: "index_users_on_phone_number_normalized", unique: true, using: :btree
+    t.index ["phone_number_normalized", "name"], name: "index_users_on_phone_number_normalized_and_name", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 

--- a/spec/controllers/admin/twilio_controller_spec.rb
+++ b/spec/controllers/admin/twilio_controller_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Admin::TwilioController, type: :controller do
     end
 
     it 'reuses conversation' do
-      c = create :conversation, user: user, from_phone: from_number, ride_zone: ride_zone
+      post :sms, params: {'From' => from_number, 'To' => to_number, 'Body' => msg}
+      c = Conversation.last
       post :sms, params: {'From' => from_number, 'To' => to_number, 'Body' => msg}
       Conversation.count.should == 1
       Message.last.conversation_id.should == c.id


### PR DESCRIPTION
Allow same phone user with different roles. Email still has unique index, so testers would need to use their.email+something@domain.com to differentiate.