### PR TITLE
First version of the cable-based event API for dispatch

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,3 +18,4 @@
 //= require turbolinks
 //= require addtocalendar
 //= require_tree .
+//= require_tree ./channels

--- a/app/assets/javascripts/channels/ride_zone.js
+++ b/app/assets/javascripts/channels/ride_zone.js
@@ -1,0 +1,34 @@
+// app/assets/javascripts/channels/ride_zone.js
+
+//= require cable
+//= require_self
+//= require_tree .
+
+// Call this from the dispatch page to set up the RideZoneChannel to the server
+function createRideZoneChannel(rideZoneId, connectedCallBack, disconnectedCallBack, receiveCallBack) {
+  "use strict";
+
+  if (App.ridezone) {
+    App.cable.subscriptions.remove(App.ridezone)
+  }
+  App.ridezone = App.cable.subscriptions.create({channel: 'RideZoneChannel', id: rideZoneId}, {
+    // Built-in, called by framework whenever connection is established
+    connected: function (data) {
+      console.log('RideZoneChannel connection to server established: '+rideZoneId); // debugging
+      connectedCallBack();
+    },
+
+    // Built-in, called by framework whenever connection is broken
+    disconnected: function() {
+      console.log('RideZoneChannel connection to server disconnected: '+rideZoneId); // debugging
+      disconnectedCallBack();
+    },
+
+    // Built-in, called by framework whenever data arrives from server
+    received: function(data) {
+      console.log('RideZoneChannel: '+rideZoneId + ' got data ' + JSON.stringify(data)); // debugging
+      receiveCallBack(data);
+    }
+
+  });
+}

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,5 +1,19 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+    def find_verified_user
+      if current_user = env['warden'].user # devise user
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/ride_zone_channel.rb
+++ b/app/channels/ride_zone_channel.rb
@@ -1,0 +1,9 @@
+class RideZoneChannel < ApplicationCable::Channel
+  # called when a new dispatch connection is established
+  def subscribed
+    logger.debug "RideZone connection from #{current_user.name} to #{params[:id]}"
+
+    # Set up a stream specific to this ride zone
+    stream_from "ride_zone_#{params[:id]}"
+  end
+end

--- a/app/controllers/api/v1/twilio_controller.rb
+++ b/app/controllers/api/v1/twilio_controller.rb
@@ -41,7 +41,7 @@ module Api::V1
       from_phone = PhonyRails.normalize_number(params['From'])
       @user = User.find_by_phone_number_normalized(from_phone)
       if @user.nil?
-        @user = User.create!(name: '', user_type: 'rider', password: '12345678', phone_number: from_phone, phone_number_normalized: from_phone, email: "#{from_phone}@example.com")
+        @user = User.create!(name: '', user_type: :voter, ride_zone: @ride_zone, password: '12345678', phone_number: from_phone, phone_number_normalized: from_phone, email: "#{from_phone}@example.com")
         # todo: user role as passenger?
       end
       @conversation = Conversation.where(user_id: @user.id).where.not(status: :closed).first

--- a/app/controllers/dispatch_controller.rb
+++ b/app/controllers/dispatch_controller.rb
@@ -1,0 +1,5 @@
+class DispatchController < ApplicationController
+  def index
+  end
+end
+

--- a/app/models/ride_zone.rb
+++ b/app/models/ride_zone.rb
@@ -25,4 +25,14 @@ class RideZone < ApplicationRecord
       scheduled_rides: Ride.where(ride_zone_id: self.id, status: :scheduled).count,
     }
   end
+
+  # call this to broadcast an event for this ride zone
+  # the object must respond to :api_json
+  def event(event_type, object, tag = nil)
+    event = {
+      event_type: event_type,
+      tag || object.class.name.downcase => object.send(:api_json)
+    }
+    ActionCable.server.broadcast "ride_zone_#{self.id}", event
+  end
 end

--- a/app/views/dispatch/index.html.haml
+++ b/app/views/dispatch/index.html.haml
@@ -1,0 +1,11 @@
+:javascript
+  function c() { document.getElementById('server-status').innerText = "Connected!"; }
+  function d() { document.getElementById('server-status').innerText = "Disconnected..."; }
+  function r(data) { document.getElementById('received-data').innerText = JSON.stringify(data); }
+  createRideZoneChannel(1, c, d, r);
+  createRideZoneChannel(1, c, d, r);
+  createRideZoneChannel(1, c, d, r);
+Dispatch App
+
+<div id="server-status">Waiting for connection</div>
+<div id="received-data">No data</div>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,8 +5,8 @@
     %title 🚕 the Vote
     = csrf_meta_tags
 
-    -# if request.original_url.include?('messages')
-      // = action_cable_meta_tag
+    - if request.original_url.include?('dispatch')
+      = action_cable_meta_tag
 
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
     %meta{ name: "apple-mobile-web-app-capable", content: "yes" }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,11 +12,11 @@
 
 Rails.application.configure do
   Rails.env = 'development'
-  
+
   # Websocket for messages
-  # config.action_cable.url = "ws://local.drive.vote:3000/cable"
-  # config.action_cable.allowed_request_origins = ['http://local.drive.vote:3000']
-  
+  config.action_cable.url = "ws://local.drive.vote:3000/cable"
+  config.action_cable.allowed_request_origins = ['http://local.drive.vote:3000']
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -45,7 +45,7 @@ Rails.application.configure do
   end
 
   config.active_job.queue_adapter = :sidekiq
-  
+
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
@@ -57,7 +57,7 @@ Rails.application.configure do
 
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
-  
+
   # More info here:
   # http://weblog.rubyonrails.org/2015/1/16/This-week-in-Rails-tokens-migrations-method-source-and-more/
   config.active_record.time_zone_aware_types = [:datetime, :time]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,8 +2,8 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Websocket for messages
-  # config.action_cable.url = "ws://drive.vote/cable"
-  # config.action_cable.allowed_request_origins = ['https://drive.vote']
+  config.action_cable.url = 'wss://drive.vote/cable'
+  config.action_cable.allowed_request_origins = ['https://drive.vote']
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,9 @@ Rails.application.routes.draw do
   # and the meta tag in application.html.haml
   # and lined in development.rb and production.rb
   # Serve websocket cable requests in-process
-  # mount ActionCable.server => '/cable'
+  mount ActionCable.server => '/cable'
 
+  resources :dispatch, only: [:index]
 
   resources :driving do
     collection do

--- a/doc/drive_the_vote_dispatch_api.md
+++ b/doc/drive_the_vote_dispatch_api.md
@@ -63,14 +63,14 @@ This event indicates an existing conversation has changed its status, lifecycle,
 This event indicates a new message has been attached to a conversation. The message could come from the voter or from a dispatcher.
 
 	{
-		"type" : "event",
 		"event_type" : "new_message",
 		"message" : {
 			"id" : unique_id_integer,
 			"conversation_id" : id_of_conversation_integer,
 			"from_phone" : "phone number originating the message",
 			"is_from_voter" : true | false,
-			"body" : "text of the SMS message"
+			"body" : "text of the SMS message",
+			"created_at" : integer_unix_epoch_time
 		}
 	}
 
@@ -116,35 +116,19 @@ This event indicates a new driver has been added to the ride zone.
 		"driver" : {
 			"id" : unique_id_integer,
 			"name" : "driver name",
-			"phone" : "phone number"
-		}
-	}
-
-##### Driver Availability Change
-This event indicates a driver's availability has changed - whether they are available "on duty" or not available "off duty". The driver's most recent location, if known, is included.
-
-	{
-		"event_type" : "driver_availability_changed",
-		"driver" : {
-			"id" : unique_id_integer,
-			"name" : "driver name",
 			"phone" : "phone number",
 			"available" : true | false,
 			"latitude" : decimal_number,
 			"longitude" : decimal_number,
-			"location_timestamp" : integer_unix_epoch_time
+			"location_timestamp" : integer_unix_epoch_time,
+			"active_ride" : nil_or_ride_object
 		}
 	}
 
-##### Driver Location Change
-This event indicates a driver's location has changed.
+##### Driver Changed
+This event indicates a driver's location, ride status, or availability has changed
 
 	{
-		"event_type" : "driver_location_changed",
-		"driver" : {
-			"id" : unique_id_integer,
-			"latitude" : decimal_number,
-			"longitude" : decimal_number,
-			"location_timestamp" : integer_unix_epoch_time
-		}
+		"event_type" : "driver_changed",
+		"driver" : *same as new_driver*
 	}

--- a/spec/controllers/api/v1/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/conversations_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Api::V1::ConversationsController, :type => :controller, focus:true do
+RSpec.describe Api::V1::ConversationsController, :type => :controller do
 
   describe 'get conversation' do
     let(:rz) { create :ride_zone }

--- a/spec/controllers/driving_controller_spec.rb
+++ b/spec/controllers/driving_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DrivingController, :type => :controller do
   let(:rz) { create :ride_zone }
-  let(:driver) { d = create :user; d.add_role(:driver, rz); d }
+  let(:driver) { create :driver_user, ride_zone: rz }
   let(:car_location) { {latitude: 35, longitude: -122} }
 
   before :each do
@@ -114,7 +114,7 @@ RSpec.describe DrivingController, :type => :controller do
     end
 
     it 'does not allow stealing rides' do
-      ride.update_attribute :driver_id, 999
+      ride.assign_driver(create :driver_user, ride_zone: rz)
       post :accept_ride, params: {ride_id: ride.id}
       expect(response).to_not be_successful
       expect(response.status).to eq(400)

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -10,6 +10,19 @@ RSpec.describe Conversation, type: :model do
     end
   end
 
+  describe 'event generation' do
+    it 'sends new conversation event' do
+      expect_any_instance_of(RideZone).to receive(:event).with(:new_conversation, anything)
+      create :conversation
+    end
+
+    it 'sends conversation update event' do
+      c = create :conversation
+      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
+      c.update_attribute(:status, :closed)
+    end
+  end
+
   describe 'lifecycle calculation' do
     it 'detects language' do
       c = create :conversation

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -5,6 +5,21 @@ RSpec.describe Message, type: :model do
   it { should belong_to(:conversation) }
   it { should belong_to(:ride_zone) }
 
+  describe 'event generation' do
+    let!(:convo) { create :conversation }
+
+    it 'sends new message event' do
+      expect_any_instance_of(RideZone).to receive(:event).with(:new_message, anything)
+      create :message, conversation: convo
+    end
+
+    it 'sends message update event' do
+      m = create :message, conversation: convo
+      expect_any_instance_of(RideZone).to receive(:event).with(:message_changed, anything)
+      m.update_attribute(:sms_status, 'rejected')
+    end
+  end
+
   it 'reports is_from_voter' do
     rz = create :ride_zone
     convo = create :conversation, ride_zone: rz, to_phone: rz.phone_number

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Ride, type: :model do
     it 'sends ride update event but not driver' do
       r = create :ride
       expect_any_instance_of(RideZone).to receive(:event).with(:ride_changed, anything)
-      RideZone.any_instance.should_not_receive(:event).with(:driver_changed, anything)
+      expect_any_instance_of(RideZone).to_not receive(:event).with(:driver_changed, anything)
       r.update_attribute(:pickup_at, Time.now)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,4 +22,32 @@ RSpec.describe User, :type => :model do
     u.update_attribute :longitude, -122
     expect(u.reload.location_updated_at).to_not be_nil
   end
+
+  describe 'event generation' do
+    let(:rz) { create :ride_zone }
+
+    it 'does not send event for new voter' do
+      expect_any_instance_of(RideZone).to_not receive(:event)
+      create :voter_user, ride_zone: rz
+    end
+
+    it 'does not send event for updated voter' do
+      u = create :voter_user, ride_zone: rz
+      expect_any_instance_of(RideZone).to_not receive(:event)
+      u.update_attribute(:name, 'foobar')
+    end
+
+    it 'sends new driver event' do
+      expect_any_instance_of(RideZone).to receive(:event).with(:new_driver, anything, :driver)
+      # cannot use factory because it doesn't create users the same way code
+      # does with transient attributes
+      User.create! name: 'foo', user_type: 'driver', ride_zone: rz, email: 'foo@example.com', phone_number: '+14155555555', phone_number_normalized: '+14155555555', password: '123456789'
+    end
+
+    it 'sends driver update event on change' do
+      d = create :driver_user, ride_zone: rz
+      expect_any_instance_of(RideZone).to receive(:event).with(:driver_changed, anything, :driver)
+      d.update_attribute(:name, 'foo bar')
+    end
+  end
 end


### PR DESCRIPTION
Two main pieces:
- The javascript and ride_zone_channel.rb and configurations to enable inbound cable connections
- Key objects conversation, ride, message, driver (user) will broadcast events to their ride zone channel on creation and update

@john @messick sorry it's so big, I have a tendency to want to get an entire first pass in vs. adding nibbles at a time. push back if you'd like smaller chunks.

@messick I used the expect syntax on my new tests :-)