### PR TITLE
Add map wrapper

### DIFF
--- a/public/map/icon-driver.svg
+++ b/public/map/icon-driver.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 38 57"
+        >
+
+    <path d="M0,19
+             A19,19 0 0,1 19,0
+             A19,19 0 0,1 38,19
+             A65,65 0 0,1 19,57
+             A65,65 0 0,1 0,19
+             " style="fill: #ff9900;"></path>
+    
+    <text style="text-anchor: middle;
+                 fill: black;
+                 font-size: 30px;
+                 font-family: Arial
+                 " x="19" y="28">🚗</text>
+
+</svg>

--- a/public/map/icon-poll.svg
+++ b/public/map/icon-poll.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 38 57"
+        >
+
+    <path d="M0,19
+             A19,19 0 0,1 19,0
+             A19,19 0 0,1 38,19
+             A65,65 0 0,1 19,57
+             A65,65 0 0,1 0,19
+             " style="fill: #ff9900;"></path>
+    
+    <text style="text-anchor: middle;
+                 fill: black;
+                 font-size: 30px;
+                 font-family: Arial
+                 " x="19" y="32">🏛</text>
+
+</svg>

--- a/public/map/icon-voter.svg
+++ b/public/map/icon-voter.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     viewBox="0 0 38 57"
+        >
+
+    <path d="M0,19
+             A19,19 0 0,1 19,0
+             A19,19 0 0,1 38,19
+             A65,65 0 0,1 19,57
+             A65,65 0 0,1 0,19
+             " style="fill: #ff9900;"></path>
+    
+    <text style="text-anchor: middle;
+                 fill: black;
+                 font-size: 30px;
+                 font-family: Arial
+                 " x="19" y="34">😺</text>
+
+</svg>

--- a/public/map/index.html
+++ b/public/map/index.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>Map Wrapper</title>
+	<link rel="stylesheet" href="https://writ.cmcenroe.me/1.0.3/writ.min.css">
+    <style>
+      body {
+        width: 80%;
+        margin: 2em;
+      }
+      #gmap, #lmap {
+        height: 300px;
+        margin: 1em 0;
+      }
+    </style>
+</head>
+<body>
+    <h1>Simple Map Wrapper</h1>
+    <p>
+        Two maps generated with almost-identical code, showing a simple
+        wrapper for Google Maps or OpenStreetMap-based Leaflet.
+    </p>
+    <p>
+        Code for each looks approximately like this; view source for details:
+    </p>
+    <pre>
+new Map(document.getElementById('map'),
+        function(map) {
+          map.addMarker(37.770444, -122.434960, map.icons.voter, 'Hello World!', 'http://example.com');
+          map.addMarker(37.769079, -122.433674, map.icons.poll,  'Hello World!');
+          map.addMarker(37.771612, -122.426836, map.icons.driver);
+        },
+        {lat: 37.77073, lon: -122.43020, zoom: 16});
+</pre>
+    <p>
+        Defaults are mostly left uncustomized, except for default scrollwheel zoom, which
+        <a href="http://content.stamen.com/stamens-checklist-for-maps">should not be used in a non-fullscreen map</a>.
+    </p>
+    <div id="gmap"></div>
+    <div id="lmap"></div>
+    <script>
+    
+        // Wrapper for different kinds of maps. Currently supports
+        // OpenStreetMap via Leaflet with Stamen tiles, and Google Maps.
+        // To use Google, provide google_api_key in args parameter.
+        // Loaded map is passed to callback when ready for use.
+        function Map(element, callback, args)
+        {
+            this._gmap = null;
+            this._lmap = null;
+            
+            var view = {
+                lat: (args && args.lat || 37.77073),
+                lon: (args && args.lon || -122.43020),
+                zoom: (args && args.zoom || 16)
+                };
+
+            if(args && args.google_api_key) {
+                this._loadGoogleMap(element, view, callback, args.google_api_key);
+
+            } else {
+                this._loadLeafletMap(element, view, callback);
+            }
+        }
+        
+        Map.prototype = {
+        
+            // built-in icon options.
+            icons: {
+                voter: {url: 'icon-voter.svg', w: 38, h: 57},
+                driver: {url: 'icon-driver.svg', w: 38, h: 57},
+                poll: {url: 'icon-poll.svg', w: 38, h: 57}
+            },
+        
+            // Add a marker with an optional text-only popup.
+            addMarker: function(lat, lon, icon, name, href)
+            {
+                var content;
+                
+                if(href && name) {
+                    content = document.createElement('a');
+                    content.appendChild(document.createTextNode(name));
+                    content.href = href;
+                } else if(name) {
+                    content = document.createTextNode(name);
+                }
+            
+                if(this._gmap) {
+                    this._addGoogleMarker(lat, lon, icon, content);
+
+                } else if(this._lmap) {
+                    this._addLeafletMarker(lat, lon, icon, content);
+                }
+            },
+            
+            _addGoogleMarker: function(lat, lon, icon, content)
+            {
+                var gmap = this._gmap,
+                    icon = {url: icon.url,
+                            size: {width: icon.w, height: icon.h},
+                            anchor: {x: icon.w/2, y: icon.h},
+                            labelOrigin: {x: icon.w/2, y: 0}},
+                    gmarker = new google.maps.Marker({
+                        position: {lat: lat, lng: lon},
+                        icon: icon,
+                        map: gmap,
+                        title: name
+                    });
+                
+                if(content) {
+                    var infowindow = new google.maps.InfoWindow({content: content});
+                    gmarker.addListener('click', function() { infowindow.open(gmap, gmarker) });
+                }
+            },
+            
+            _addLeafletMarker: function(lat, lon, icon, content)
+            {
+                var icon = L.icon({iconUrl: icon.url,
+                                   iconSize: [icon.w, icon.h],
+                                   iconAnchor: [icon.w/2, icon.h],
+                                   popupAnchor: [0, -icon.h]}),
+                    lmarker = L.marker([lat, lon], {icon: icon}).addTo(this._lmap);
+                
+                if(content) {
+                    lmarker.bindPopup(content);
+                }
+            },
+        
+            _loadGoogleMap: function(element, view, callback, api_key)
+            {
+                if(!window.google || !window.google.maps.Map)
+                {
+                    // Include script for Google Maps, see:
+                    // https://developers.google.com/maps/documentation/javascript/tutorial
+                    
+                    var script = document.createElement('script');
+                    script.setAttribute('src', 'https://maps.googleapis.com/maps/api/js?key='+api_key);
+                    document.head.appendChild(script);
+                }
+                
+                function awaitGoogleMap(map, element, view, callback)
+                {
+                    // Wait another 50msec if Google Maps is not loaded.
+                    if(!window.google || !window.google.maps.Map) {
+                        return window.setTimeout(awaitGoogleMap, 50, map, element, view, callback);
+                    }
+
+                    // Set default view, and turn off scrollwheel zoom.
+                    var opts = {
+                        center: {lat: view.lat, lng: view.lon},
+                        zoom: view.zoom,
+                        scrollwheel: false
+                        };
+
+                    map._gmap = new google.maps.Map(element, opts);
+                    callback(map);
+                }
+            
+                awaitGoogleMap(this, element, view, callback);
+            },
+            
+            _loadLeafletMap: function(element, view, callback)
+            {
+                if(!window.L || !window.L.map)
+                {
+                    // Include script and stylesheets for Leaflet, see:
+                    // http://leafletjs.com/examples/quick-start.html
+                    
+                    var script = document.createElement('script'),
+                        link = document.createElement('link');
+
+                    script.setAttribute('src', 'https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.js');
+                    link.setAttribute('href', 'https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.css');
+                    link.setAttribute('rel', 'stylesheet');
+
+                    document.head.appendChild(script);
+                    document.head.appendChild(link);
+                }
+                
+                function awaitLeaflet(map, element, view, callback)
+                {
+                    // Wait another 50msec if Leaflet is not loaded.
+                    if(!window.L || !window.L.map) {
+                        return window.setTimeout(awaitLeaflet, 50, map, element, view, callback);
+                    }
+
+                    // Set default view, and turn off scrollwheel zoom.
+                    var opts = {
+                        center: [view.lat, view.lon],
+                        zoom: view.zoom,
+                        scrollWheelZoom: false
+                        };
+
+                    map._lmap = L.map(element, opts);
+                
+                    // Add Stamen tile layer.
+                    L.tileLayer('http://tile.stamen.com/terrain/{z}/{x}/{y}@2x.png', {
+                        attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+                        maxZoom: 18
+                    }).addTo(map._lmap);
+                
+                    callback(map);
+                }
+            
+                awaitLeaflet(this, element, view, callback);
+            }
+            
+        };
+    
+        function on_loaded(map)
+        {
+            map.addMarker(37.770444, -122.434960, map.icons.voter, 'Hello World!', 'http://example.com');
+            map.addMarker(37.769079, -122.433674, map.icons.poll, 'Hello World!');
+            map.addMarker(37.771612, -122.426836, map.icons.driver);
+        }
+        
+        var gmap = new Map(document.getElementById('gmap'), on_loaded,
+                           {'google_api_key': 'AIzaSyDyJ3LTbJGAEIKjqYj3-gFDbAZ3BLo6sGo',
+                            lat: 37.77073, lon: -122.43020, zoom: 16});
+
+        var lmap = new Map(document.getElementById('lmap'), on_loaded,
+                           {lat: 37.77073, lon: -122.43020, zoom: 16});
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Introduces a simple web map wrapper for Google Maps or OpenStreetMap-based Leaflet. Features three kinds of map markers, for voters, drivers, and poll locations. Code for this is not yet packaged into a reusable Javascript library.

Remaining work includes:

- [ ] Programmatically add map points
- [ ] Move pins in real time
- [ ] Add to Rails asset pipeline

<img width="996" alt="screen shot 2016-08-11 at 11 04 45 pm" src="https://cloud.githubusercontent.com/assets/58730/17614070/0ac8deb6-6018-11e6-87df-abe0dd2ced32.png">

Sample usage:

```Javascript
new Map(document.getElementById('map'),
        function(map) {
          map.addMarker(37.770444, -122.434960, map.icons.voter, 'Hello World!', 'http://example.com');
          map.addMarker(37.769079, -122.433674, map.icons.poll,  'Hello World!');
          map.addMarker(37.771612, -122.426836, map.icons.driver);
        },
        {lat: 37.77073, lon: -122.43020, zoom: 16});
```
